### PR TITLE
fix ROSA console URL and attribute names

### DIFF
--- a/content/modules/ROOT/pages/module-04.adoc
+++ b/content/modules/ROOT/pages/module-04.adoc
@@ -8,9 +8,9 @@ Your ROSA cluster is available at:
 
 [%autowidth,frame=ends,stripes=even]
 |===
-| ROSA console URL: | {rosa_cluster_rosa_console_url}
+| ROSA console URL: | {rosa_cluster_rosa_console_url}[{rosa_cluster_rosa_console_url}^]
 | ROSA user: | {rosa_cluster_rosa_admin_user}
-| ROSA password: | {rrosa_cluster_rosa_admin_password}
+| ROSA password: | {rosa_cluster_rosa_admin_password}
 |===
 
 * Click on the Rosa console URL and use the provided User and Password details to login:


### PR DESCRIPTION
* ROSA console URL isn't working because OCP console wont open in an iframe.  I added some adoc to help open in a new tab.
* misspelled asciidoc attribute for rosa password.